### PR TITLE
Issue#9: Add ability to attach a security group to a specific port

### DIFF
--- a/lib/fog/rackspace/requests/networking_v2/update_port.rb
+++ b/lib/fog/rackspace/requests/networking_v2/update_port.rb
@@ -3,7 +3,7 @@ module Fog
     class NetworkingV2
       class Real
         def update_port(port)
-          data = {:port => {:name => port.name}}
+          data = {:port => {:name => port.name,:security_groups => port.security_groups}}
 
           request(
             :method  => 'PUT',


### PR DESCRIPTION
Update a specific port with a security group tested on Rackspace public cloud.
https://github.com/fog/fog-rackspace/issues/19