### PR TITLE
Adds start and stop server operations API 

### DIFF
--- a/lib/fog/rackspace/compute_v2.rb
+++ b/lib/fog/rackspace/compute_v2.rb
@@ -81,6 +81,8 @@ module Fog
       request :unrescue_server
       request :list_addresses
       request :list_addresses_by_network
+      request :start_server
+      request :stop_server
 
       request :create_image
       request :list_images

--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -526,6 +526,39 @@ module Fog
           true
         end
 
+        # This operation starts a stopped server, and changes its status to ACTIVE.
+        # Prior to running this command, the server status must be SHUTTOFF
+        # @param [String] server_id id of server to rescue
+        # @return [Boolean] returns true if call to put server in ACTIVE mode reports success
+        # @raise [Fog::Rackspace::Errors::NotFound] - HTTP 404
+        # @raise [Fog::Rackspace::Errors::BadRequest] - HTTP 400
+        # @raise [Fog::Rackspace::Errors::InternalServerError] - HTTP 500
+        # @raise [Fog::Rackspace::Errors::ServiceError]
+        # @note Rescue mode is only guaranteed to be active for 90 minutes
+        # @see https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#start-specified-server
+        def start
+          requires :identity
+          service.start_server(identity)
+          true
+        end
+
+        # This operation stops a running server, and changes the server status to SHUTOFF
+        # and changes the clean_shutdown parameter to TRUE.
+        # Prior to running this command, the server status must be ACTIVE or ERROR.
+        # @param [String] server_id id of server to rescue
+        # @return [Boolean] returns true if call to put server in SHUTOFF mode reports success
+        # @raise [Fog::Rackspace::Errors::NotFound] - HTTP 404
+        # @raise [Fog::Rackspace::Errors::BadRequest] - HTTP 400
+        # @raise [Fog::Rackspace::Errors::InternalServerError] - HTTP 500
+        # @raise [Fog::Rackspace::Errors::ServiceError]
+        # @note Rescue mode is only guaranteed to be active for 90 minutes
+        # @see https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#stop-specified-server
+        def stop
+          requires :identity
+          service.stop_server(identity)
+          true
+        end
+
         # Place existing server into rescue mode, allowing for offline editing of configuration. The original server's disk is attached to a new instance of the same base image for a period of time to facilitate working within rescue mode.  The original server will be automatically restored after 90 minutes.
         # @return [Boolean] returns true if call to put server in rescue mode reports success
         # @raise [Fog::Rackspace::Errors::NotFound] - HTTP 404

--- a/lib/fog/rackspace/requests/compute_v2/start_server.rb
+++ b/lib/fog/rackspace/requests/compute_v2/start_server.rb
@@ -1,0 +1,39 @@
+module Fog
+  module Compute
+    class RackspaceV2
+      class Real
+        # This operation starts a stopped server, and changes its status to ACTIVE.
+        # Prior to running this command, the server status must be SHUTTOFF
+        # @param [String] server_id id of server to rescue
+        # @return [Excon::Response] response
+        # @raise [Fog::Rackspace::Errors::NotFound] - HTTP 404
+        # @raise [Fog::Rackspace::Errors::BadRequest] - HTTP 400
+        # @raise [Fog::Rackspace::Errors::InternalServerError] - HTTP 500
+        # @raise [Fog::Rackspace::Errors::ServiceError]
+        # @note Rescue mode is only guaranteed to be active for 90 minutes
+        # @see https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#start-specified-server
+
+        def start_server(server_id)
+          data = {
+            'os-start' => nil
+          }
+
+          request(
+            :body => Fog::JSON.encode(data),
+            :expects => [202],
+            :method => 'POST',
+            :path => "servers/#{server_id}/action"
+          )
+        end
+      end
+
+      class Mock
+        def start_server(server_id)
+          server = self.data[:servers][server_id]
+          server["status"] = "ACTIVE"
+          response(:status => 202)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/rackspace/requests/compute_v2/stop_server.rb
+++ b/lib/fog/rackspace/requests/compute_v2/stop_server.rb
@@ -1,0 +1,40 @@
+module Fog
+  module Compute
+    class RackspaceV2
+      class Real
+        # This operation stops a running server, and changes the server status to SHUTOFF
+        # and changes the clean_shutdown parameter to TRUE.
+        # Prior to running this command, the server status must be ACTIVE or ERROR.
+        # @param [String] server_id id of server to rescue
+        # @return [Excon::Response] response
+        # @raise [Fog::Rackspace::Errors::NotFound] - HTTP 404
+        # @raise [Fog::Rackspace::Errors::BadRequest] - HTTP 400
+        # @raise [Fog::Rackspace::Errors::InternalServerError] - HTTP 500
+        # @raise [Fog::Rackspace::Errors::ServiceError]
+        # @note Rescue mode is only guaranteed to be active for 90 minutes
+        # @see https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#stop-specified-server
+
+        def stop_server(server_id)
+          data = {
+            'os-stop' => nil
+          }
+
+          request(
+            :body => Fog::JSON.encode(data),
+            :expects => [202],
+            :method => 'POST',
+            :path => "servers/#{server_id}/action"
+          )
+        end
+      end
+
+      class Mock
+        def stop_server(server_id)
+          server = self.data[:servers][server_id]
+          server["status"] = "SHUTOFF"
+          response(:status => 202)
+        end
+      end
+    end
+  end
+end

--- a/tests/rackspace/models/compute_v2/server_tests.rb
+++ b/tests/rackspace/models/compute_v2/server_tests.rb
@@ -150,6 +150,18 @@ Shindo.tests('Fog::Compute::RackspaceV2 | server', ['rackspace']) do
     end
 
     @instance.wait_for { ready?('RESCUE') }
+    tests('#start').succeeds do
+      @instance.start
+    end
+
+    sleep 30 unless Fog.mocking?
+    @instance.wait_for { ready?('ACTIVE') }
+    tests('#stop').succeeds do
+      @instance.stop
+    end
+
+    sleep 30 unless Fog.mocking?
+    @instance.wait_for { ready?('SHUTOFF') }
     tests('#unrescue').succeeds do
       @instance.unrescue
     end

--- a/tests/rackspace/requests/compute_v2/server_tests.rb
+++ b/tests/rackspace/requests/compute_v2/server_tests.rb
@@ -156,6 +156,17 @@ Shindo.tests('Fog::Compute::RackspaceV2 | server_tests', ['rackspace']) do
     end
     wait_for_server_state(service, server_id, 'RESCUE', 'ACTIVE')
 
+    tests('#start_server').formats(rescue_server_format, false) do
+      service.start_server(server_id)
+    end
+    wait_for_server_state(service, server_id, 'ACTIVE', 'ERROR')
+
+
+    tests('#stop_server').formats(rescue_server_format, false) do
+      service.stop_server(server_id)
+    end
+    wait_for_server_state(service, server_id, 'SHUTOFF')
+
     tests('#unrescue_server').succeeds do
       service.unrescue_server(server_id)
     end


### PR DESCRIPTION
Server operations API:
[Start specified server](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#start-specified-server)
[Stop specified server](https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#stop-specified-server)