### PR TITLE
Rescue Excon::Error::Socket and authenticate

### DIFF
--- a/lib/fog/rackspace/service.rb
+++ b/lib/fog/rackspace/service.rb
@@ -45,6 +45,13 @@ module Fog
           first_attempt = false
           authenticate
           retry
+        rescue Excon::Error::Socket => ees
+          if ees.message && ees.message.downcase.include?('broken pipe')
+            raise ees unless first_attempt
+            first_attempt = false
+            authenticate
+            retry
+          end
         end
 
         process_response(response) if parse_json


### PR DESCRIPTION
Rackspace users started reporting intermittent "broken pipe" errors that seem to be related to authentication. This rescues those errors and attempts to authenticate, and users reported this fixing the problem.

See https://github.com/excon/excon/issues/641 for more details.