### PR TITLE
Escape the source container and object name to be copied from

### DIFF
--- a/lib/fog/rackspace/requests/storage/copy_object.rb
+++ b/lib/fog/rackspace/requests/storage/copy_object.rb
@@ -15,7 +15,7 @@ module Fog
         # @raise [Fog::Storage::Rackspace::InternalServerError] - HTTP 500
         # @raise [Fog::Storage::Rackspace::ServiceError]
         def copy_object(source_container_name, source_object_name, target_container_name, target_object_name, options={})
-          headers = { 'X-Copy-From' => "/#{source_container_name}/#{source_object_name}" }.merge(options)
+          headers = { 'X-Copy-From' => "/#{Fog::Rackspace.escape(source_container_name)}/#{Fog::Rackspace.escape(source_object_name)}" }.merge(options)
           request({
             :expects  => 201,
             :headers  => headers,


### PR DESCRIPTION
Rackspace seems to 500 if your source object name has unicode characters that are not escaped.

I tried to get the test suite running locally, but it's giving a the following error:
```
LoadError: cannot load such file -- fog/schema/data_validator
  tests/helpers/formats_helper.rb:1:in `require'
  tests/helpers/formats_helper.rb:1:in `<top (required)>'
```

I've been running this patch in production for 3 months without issue.

Fixes #6.