### PR TITLE
URI: encode method obsolete after ruby > 3

### DIFF
--- a/lib/fog/rackspace/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/rackspace/requests/storage/delete_multiple_objects.rb
@@ -53,7 +53,7 @@ module Fog
         def delete_multiple_objects(container, object_names, options = {})
           body = object_names.map do |name|
             object_name = container ? "#{ container }/#{ name }" : name
-            URI.encode(object_name)
+            URI.encode_www_form_component(object_name)
           end.join("\n")
 
           response = request({


### PR DESCRIPTION
Encode updated to encode_www_form_component method